### PR TITLE
230329 PR: 페이지 이탈 시 경고창과 동시에 서버에게 타임 데이터 전송...

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,10 +8,12 @@ import Main from './pages/Main';
 import Ranking from './pages/Ranking';
 import Timer from './pages/Timer';
 import TodoPage from './pages/TodoPage';
+import TimerController from './components/timer/TimerController';
 
 function App() {
   const location = useLocation();
   const hiddenPaths: string[] = ['/', '/timer', '/login'];
+  const TimerControll = TimerController();
 
   return (
     <>
@@ -23,7 +25,9 @@ function App() {
           <Route path='/callback' element={<CallBack />}></Route>
           <Route path='/todo' element={<TodoPage />}></Route>
           <Route path='/rank' element={<Ranking />}></Route>
-          <Route path='/timer' element={<Timer />}></Route>
+          <Route
+            path='/timer'
+            element={<Timer props={TimerControll} />}></Route>
         </Route>
       </Routes>
       {!hiddenPaths.includes(location.pathname) && <TimeModal />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,6 @@ function App() {
   const location = useLocation();
   const hiddenPaths: string[] = ['/', '/timer', '/login'];
   const TimerControll = TimerController();
-
   return (
     <>
       <Routes>

--- a/src/api/timer.ts
+++ b/src/api/timer.ts
@@ -1,5 +1,4 @@
 import api from './ApiController';
-
 export interface RecordBody {
   hours?: string;
   minute?: string;
@@ -9,21 +8,22 @@ export interface RecordBody {
   yesterdayDateInfo?: string;
   todayDateInfo?: string;
 }
+export const timerApis = {
+  // 타임 정지시 기록하기
+  getRecord: async (body: RecordBody) => {
+    const res = await api.post('/api/v1/timer/recode', { ...body });
+    return res;
+  },
 
-// 타임 정지시 기록하기
-export const getRecord = async (body: RecordBody) => {
-  const res = await api.post('/api/v1/timer/recode', { ...body });
-  return res;
-};
+  // 오늘의 타임 기록 가져오기
+  getTodayRecordInfo: async (body: RecordBody) => {
+    const res = await api.post('/api/v1/timer/todayInfo', { ...body });
+    return res;
+  },
 
-// 오늘의 타임 기록 가져오기
-export const getTodayRecordInfo = async (body: RecordBody) => {
-  const res = await api.post('/api/v1/timer/todayInfo', { ...body });
-  return res;
-};
-
-// 이전날과의 시간 비교
-export const getYesterDayCompareRecord = async (body: RecordBody) => {
-  const res = await api.post('/api/v1/timer/compareYes', { ...body });
-  return res;
+  // 이전날과의 시간 비교
+  getYesterDayCompareRecord: async (body: RecordBody) => {
+    const res = await api.post('/api/v1/timer/compareYes', { ...body });
+    return res;
+  },
 };

--- a/src/api/timer.ts
+++ b/src/api/timer.ts
@@ -26,4 +26,9 @@ export const timerApis = {
     const res = await api.post('/api/v1/timer/compareYes', { ...body });
     return res;
   },
+  // 일주일 치 기록 가져오기
+  getWeekCompareRecord: async (body: RecordBody) => {
+    const res = await api.post('/api/v1/timer/compareWeek', { ...body });
+    return res;
+  },
 };

--- a/src/components/timer/TimeRecord.tsx
+++ b/src/components/timer/TimeRecord.tsx
@@ -1,17 +1,32 @@
 import tw from 'tailwind-styled-components';
 import userStore from '../../store/userStore';
-import { getCurrentDate, getYesterDate } from '../../utils/timer';
 
 interface Props {
-  yestaerDayCompareRecordData: string | undefined;
+  yestaerDayCompareRecordData: string;
+  weekCompareRecordData: [
+    {
+      day_of_totalTime: number;
+      member_Seq: number;
+      recodeTime: string;
+      timerCreDay: string;
+      timer_seq: number;
+    },
+  ];
 }
 
-const TimeRecord = ({ yestaerDayCompareRecordData }: Props) => {
+const TimeRecord = ({
+  yestaerDayCompareRecordData,
+  weekCompareRecordData,
+}: Props) => {
   const { userInfo } = userStore();
-
   return (
     <Wrapper>
       <Record>{yestaerDayCompareRecordData}</Record>
+      <>
+        {weekCompareRecordData?.map((data, index) => (
+          <Record key={index}>{data.recodeTime}</Record>
+        ))}
+      </>
     </Wrapper>
   );
 };

--- a/src/components/timer/TimerController.tsx
+++ b/src/components/timer/TimerController.tsx
@@ -1,10 +1,8 @@
 import { useState, useRef, useEffect } from 'react';
-import { useMutation } from 'react-query';
-import { getRecord } from '../../api/timer';
 import useRecord from '../../hooks/timer/useRecord';
 import useTimerStore from '../../store/timer';
 import userStore from '../../store/userStore';
-import { ContinuousMode, getCurrentDate, transHMC } from '../../utils/timer';
+import { ContinuousMode, transHMC } from '../../utils/timer';
 
 const TimerController = () => {
   const { time, setTime, setTimeClear } = useTimerStore();

--- a/src/components/timer/TimerController.tsx
+++ b/src/components/timer/TimerController.tsx
@@ -5,7 +5,7 @@ import userStore from '../../store/userStore';
 import { ContinuousMode, transHMC } from '../../utils/timer';
 
 const TimerController = () => {
-  const { time, setTime, setTimeClear } = useTimerStore();
+  const { time, setTime } = useTimerStore();
   const playTimeout = useRef<NodeJS.Timeout | null>(null);
   const startTime = useRef<number | null>(null);
   const pauseTime = useRef<number | null>(null);
@@ -35,6 +35,7 @@ const TimerController = () => {
         startTime.current += Date.now() - pauseTime.current;
     }
     setStatus('play');
+    localStorage.setItem('playTime', 'play');
   };
 
   const onPause = () => {
@@ -43,6 +44,7 @@ const TimerController = () => {
       pauseTime.current = Date.now();
     }
     setStatus('pause');
+    localStorage.removeItem('playTime');
   };
 
   useEffect(() => {
@@ -77,20 +79,24 @@ const TimerController = () => {
 
   // 페이지를 나갈 때 타이머 데이터 저장 함수
   const handleBeforeUnload = (event: any) => {
-    event.preventDefault();
-    event.returnValue = '';
-    // 일시정지 클릭시
-    onPause();
-    // 정지 클릭시 현재 날짜 데이터 가져와서 시작 날짜와 비교
-    const sendDate = ContinuousMode();
-    const [hours, minute, second] = transHMC(time);
-    recordMutate({
-      hours,
-      minute,
-      second,
-      timerCreDay: sendDate,
-      oauthId: userInfo.userOauthId,
-    });
+    const playStatus = localStorage.getItem('playTime');
+    if (playStatus === 'play') {
+      event.preventDefault();
+      event.returnValue = '';
+      // 일시정지 클릭시
+      onPause();
+      // 정지 클릭시 현재 날짜 데이터 가져와서 시작 날짜와 비교
+      const sendDate = ContinuousMode();
+      const [hours, minute, second] = transHMC(time);
+      recordMutate({
+        hours,
+        minute,
+        second,
+        timerCreDay: sendDate,
+        oauthId: userInfo.userOauthId,
+      });
+      localStorage.removeItem('playTime');
+    }
   };
 
   return {

--- a/src/components/timer/TimerController.tsx
+++ b/src/components/timer/TimerController.tsx
@@ -13,6 +13,7 @@ const TimerController = () => {
   const { userInfo } = userStore();
   const { mutate: recordMutate } = useRecord();
   const { hour, minute, second } = time;
+
   // 밀리초로 변환
   const totalMilliseconds = ((hour * 60 + minute) * 60 + second) * 1000;
 
@@ -90,7 +91,6 @@ const TimerController = () => {
       timerCreDay: sendDate,
       oauthId: userInfo.userOauthId,
     });
-    onStart();
   };
 
   return {

--- a/src/hooks/timer/useRecord.ts
+++ b/src/hooks/timer/useRecord.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQuery } from 'react-query';
+import { getRecord } from '../../api/timer';
+function useRecord() {
+  // 타임 정지시 기록하기
+  const { mutate } = useMutation(getRecord, {
+    onSuccess: (res) => {
+      // console.log(res);
+    },
+    onError: (error) => alert('오류 발생.'),
+  });
+  return { mutate };
+}
+
+export default useRecord;

--- a/src/hooks/timer/useRecord.ts
+++ b/src/hooks/timer/useRecord.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQuery } from 'react-query';
-import { getRecord } from '../../api/timer';
+import { timerApis } from '../../api/timer';
 function useRecord() {
   // 타임 정지시 기록하기
-  const { mutate } = useMutation(getRecord, {
+  const { mutate } = useMutation(timerApis.getRecord, {
     onSuccess: (res) => {
       // console.log(res);
     },

--- a/src/pages/Timer.tsx
+++ b/src/pages/Timer.tsx
@@ -10,28 +10,28 @@ import Time from '../components/timer/TimeView';
 import TimeRecord from '../components/timer/TimeRecord';
 import useTimerStore from '../store/timer';
 import userStore from '../store/userStore';
-import { getCurrentDate, transHMC, getYesterDate } from '../utils/timer';
-import TimerController from '../components/timer/TimerController';
+import {
+  getCurrentDate,
+  transHMC,
+  getYesterDate,
+  ContinuousMode,
+} from '../utils/timer';
+import useRecord from '../hooks/timer/useRecord';
 
 interface TimerControllerInterface {
-  status: string;
-  onStart: () => void;
-  onPause: () => void;
+  props: {
+    status: string;
+    onStart: () => void;
+    onPause: () => void;
+  };
 }
 
-const Timer = () => {
-  const { status, onStart, onPause }: TimerControllerInterface =
-    TimerController();
+const Timer = (TimerControll: TimerControllerInterface) => {
+  const { status, onStart, onPause } = TimerControll.props;
   const { userInfo } = userStore();
   const { time, setTime } = useTimerStore();
-
   // 타임 정지시 기록하기
-  const { mutate: recordMutate } = useMutation(getRecord, {
-    onSuccess: (res) => {
-      // console.log(res);
-    },
-    onError: (error) => alert('오류 발생.'),
-  });
+  const { mutate: recordMutate } = useRecord();
 
   // 오늘의 타임 기록 가져오기
   const { mutate: todayRecordInfoMutate } = useMutation(getTodayRecordInfo, {
@@ -40,6 +40,7 @@ const Timer = () => {
       if (res.data !== '해당날짜 공부 기록없음') {
         const [hours, month, sce] = res.data.recodeTime?.split(':').map(Number);
         setTime(hours, month, sce);
+        console.log('불러오기', hours, month, sce);
       } else {
         // 오늘 타임 기록이 초기화된 0초면 기록된 시작 날짜 삭제
         setTime(0, 0, 0);
@@ -79,20 +80,7 @@ const Timer = () => {
     // 일시정지 클릭시
     onPause();
     // 정지 클릭시 현재 날짜 데이터 가져와서 시작 날짜와 비교
-    const startDate = localStorage.getItem('startDate');
-    const cureentDate = getCurrentDate();
-    let sendDate = getCurrentDate();
-    if (startDate) {
-      // 타이머 시작을 전날에 한 경우 (자정이 넘어서도 지속된 타이머)
-      if (startDate < cureentDate) {
-        sendDate = startDate;
-        // 자정이 넘었으니 startDate를 서버로 전송 후 로컬에서 삭제
-        localStorage.removeItem('startDate');
-      } else {
-        // 자정이 넘지 않았으니 getCurrentDate()를 서버로 전송하면 된다.
-        sendDate = cureentDate;
-      }
-    }
+    const sendDate = ContinuousMode();
     const [hours, minute, second] = transHMC(time);
     recordMutate({
       hours,

--- a/src/pages/Timer.tsx
+++ b/src/pages/Timer.tsx
@@ -54,9 +54,22 @@ const Timer = (TimerControll: TimerControllerInterface) => {
   const {
     data: yestaerDayCompareRecordData,
     mutate: yestaerDayCompareRecordMutate,
+    isLoading: yesterLoading,
   } = useMutation(timerApis.getYesterDayCompareRecord, {
     onSuccess: (res) => {
-      console.log(res);
+      // console.log(res);
+    },
+    // onError: (error) => alert('오류 발생.'),
+  });
+
+  // 일주일치 기록 데이터 가져오기
+  const {
+    data: weekCompareRecordData,
+    mutate: weekCompareRecordMutate,
+    isLoading: weekLoading,
+  } = useMutation(timerApis.getWeekCompareRecord, {
+    onSuccess: (res) => {
+      // console.log(res);
     },
     // onError: (error) => alert('오류 발생.'),
   });
@@ -73,6 +86,10 @@ const Timer = (TimerControll: TimerControllerInterface) => {
         oauthId: userInfo.userOauthId,
         todayDateInfo: getCurrentDate(),
         yesterdayDateInfo: getYesterDate(),
+      });
+      // 일주일치 기록 데이터 가져오기
+      weekCompareRecordMutate({
+        oauthId: userInfo.userOauthId,
       });
     }
   }, []);
@@ -112,9 +129,12 @@ const Timer = (TimerControll: TimerControllerInterface) => {
           )}
         </BtnWrap>
       </StopwatchWrap>
-      <TimeRecord
-        yestaerDayCompareRecordData={yestaerDayCompareRecordData?.data}
-      />
+      {
+        <TimeRecord
+          weekCompareRecordData={weekCompareRecordData?.data}
+          yestaerDayCompareRecordData={yestaerDayCompareRecordData?.data}
+        />
+      }
     </Wrapper>
   );
 };

--- a/src/pages/Timer.tsx
+++ b/src/pages/Timer.tsx
@@ -1,11 +1,7 @@
 import { useEffect } from 'react';
 import { useMutation } from 'react-query';
 import tw from 'tailwind-styled-components';
-import {
-  getRecord,
-  getTodayRecordInfo,
-  getYesterDayCompareRecord,
-} from '../api/timer';
+import { getTodayRecordInfo, getYesterDayCompareRecord } from '../api/timer';
 import Time from '../components/timer/TimeView';
 import TimeRecord from '../components/timer/TimeRecord';
 import useTimerStore from '../store/timer';
@@ -32,7 +28,7 @@ const Timer = (TimerControll: TimerControllerInterface) => {
   const { time, setTime } = useTimerStore();
   // 타임 정지시 기록하기
   const { mutate: recordMutate } = useRecord();
-
+  console.log(time);
   // 오늘의 타임 기록 가져오기
   const { mutate: todayRecordInfoMutate } = useMutation(getTodayRecordInfo, {
     onSuccess: (res) => {
@@ -40,7 +36,6 @@ const Timer = (TimerControll: TimerControllerInterface) => {
       if (res.data !== '해당날짜 공부 기록없음') {
         const [hours, month, sce] = res.data.recodeTime?.split(':').map(Number);
         setTime(hours, month, sce);
-        console.log('불러오기', hours, month, sce);
       } else {
         // 오늘 타임 기록이 초기화된 0초면 기록된 시작 날짜 삭제
         setTime(0, 0, 0);
@@ -93,7 +88,6 @@ const Timer = (TimerControll: TimerControllerInterface) => {
 
   const onStartClick = () => {
     onStart();
-    // getCurrentDate() 로컬에 시작 데이터 저장
     localStorage.setItem('startDate', getCurrentDate());
   };
 
@@ -105,13 +99,10 @@ const Timer = (TimerControll: TimerControllerInterface) => {
         </TimeWrap>
         <BtnWrap>
           {status === 'play' ? (
-            <TimeBtn className='mr-[30px]' onClick={() => onPause()}>
-              일시정지
-            </TimeBtn>
+            <TimeBtn onClick={() => onPauseClick()}>정지</TimeBtn>
           ) : (
             <TimeBtn onClick={() => onStartClick()}>시작</TimeBtn>
           )}
-          <TimeBtn onClick={() => onPauseClick()}>공부 끝</TimeBtn>
         </BtnWrap>
       </StopwatchWrap>
       <TimeRecord
@@ -148,7 +139,6 @@ const BtnWrap = tw.div`
 text-3xl
 mt-20
 p-2
-w-[250px]
 flex
 justify-between
 `;

--- a/src/utils/timer/index.ts
+++ b/src/utils/timer/index.ts
@@ -53,3 +53,21 @@ export const dateFormat = () => {
 
   return `${year}年 ${month}月 ${day}日`;
 };
+
+export const ContinuousMode = () => {
+  const startDate = localStorage.getItem('startDate');
+  const cureentDate = getCurrentDate();
+  let sendDate = getCurrentDate();
+  if (startDate) {
+    // 타이머 시작을 전날에 한 경우 (자정이 넘어서도 지속된 타이머)
+    if (startDate < cureentDate) {
+      sendDate = startDate;
+      // 자정이 넘었으니 startDate를 서버로 전송 후 로컬에서 삭제
+      localStorage.removeItem('startDate');
+    } else {
+      // 자정이 넘지 않았으니 getCurrentDate()를 서버로 전송하면 된다.
+      sendDate = cureentDate;
+    }
+  }
+  return sendDate;
+};


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입 선택)

- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 수정 (ex. README)

## 반영 브랜치

- feat/timer_api -> dev

## 변경 사항

- 타이머 연속모드로 구현
- 페이지를 나가거나 새로고침하는 등 이탈을 하려고 할 때 경고창과 동시에 서버에게 타이머 데이터 전송
- 위에 기능을 추가함으로써 일시정지 버튼 제거
- 타이머 API 모듈화로 변경
- 타이머 일주일치 기록 불러오기
- axios 호출 intercepter 사용하기

## 유의 사항

- 이제 UI/UX 예정
